### PR TITLE
Update getstore.t

### DIFF
--- a/t/getstore.t
+++ b/t/getstore.t
@@ -12,7 +12,7 @@ if %*ENV<NO_NETWORK_TESTING> {
 }
 
 # test getstore under http
-getstore-tests('http://eu.httpbin.org/anything/Web', rx/Web/);
+getstore-tests('http://www.google.com', rx:i/google/);
 
 try require IO::Socket::SSL;
 if $! {
@@ -21,7 +21,7 @@ if $! {
 }
 
 # test getstore under https
-getstore-tests('https://www.opera.com', rx/Opera \s Web \s Browser/);
+getstore-tests('https://openssl.org', rx:i/ssl/);
 
 sub getstore-tests($url, $rx) {
     my $fname = $*SPEC.catdir($*TMPDIR, "./tmp-getstore-$*PID");
@@ -35,7 +35,7 @@ sub getstore-tests($url, $rx) {
     my $fh = open($fname);
     ok($fh, 'Opened file handle written by getstore()');
 
-    ok $fh.slurp-rest ~~ $rx, 'Found pattern in downloaded file';
+    ok($fh.slurp ~~ $rx, 'Found pattern in downloaded file');
 
     ok($fh.close, 'Close the temporary file');
 


### PR DESCRIPTION
Update URLs to fix failing test on older MacOS (Yosemite); correct .slurp-rest to .slurp; 
Addressing Issue #40