### PR TITLE
patch to add throwing exception on 4XX/5XX error, instead of returning undef

### DIFF
--- a/t/get-404.t
+++ b/t/get-404.t
@@ -1,0 +1,13 @@
+use v6;
+use Test;
+
+use LWP::Simple;
+
+plan 1;
+
+# these tests will fail if this url stops returning 404 response
+throws-like {
+    LWP::Simple.get('http://www.example.com/404');
+},
+X::LWP::Simple::Response,
+status => rx:i:s/404 Not Found/;

--- a/t/get-404.t
+++ b/t/get-404.t
@@ -7,7 +7,7 @@ plan 1;
 
 # these tests will fail if this url stops returning 404 response
 throws-like {
-    LWP::Simple.get('http://www.example.com/404');
+    LWP::Simple.get('http://www.example.com/404', :exception );
 },
 X::LWP::Simple::Response,
 status => rx:i:s/404 Not Found/;


### PR DESCRIPTION
This is a rework of the https://github.com/cosimo/perl6-lwp-simple/pull/69 to add the option of throwing an exception on an error response.

Rather than doing it always this adds a switch to turn on the behaviour.